### PR TITLE
Return tests results

### DIFF
--- a/src/eftest/runner.clj
+++ b/src/eftest/runner.clj
@@ -84,10 +84,14 @@
   ([vars opts]
    (let [start-time (System/currentTimeMillis)]
      (if (empty? vars)
-       (println "No tests found.")
+       (do
+         (println "No tests found.")
+         test/*initial-report-counters*)
        (binding [report/*context* (atom {})
                  test/report      (:report opts progress/report)]
          (test/do-report {:type :begin-test-run, :count (count vars)})
          (let [counters (test-all vars opts)
-               duration (- (System/currentTimeMillis) start-time)]
-           (test/do-report (assoc counters :type :summary, :duration duration))))))))
+               duration (- (System/currentTimeMillis) start-time)
+               summary (assoc counters :type :summary, :duration duration)]
+           (test/do-report summary)
+           summary))))))

--- a/src/eftest/runner.clj
+++ b/src/eftest/runner.clj
@@ -1,5 +1,5 @@
 (ns eftest.runner
-  "Functions to run tests writting with clojure.test or compatible libraries."
+  "Functions to run tests written with clojure.test or compatible libraries."
   (:require [clojure.java.io :as io]
             [clojure.test :as test]
             [clojure.tools.namespace.find :as find]

--- a/test/eftest/runner_test.clj
+++ b/test/eftest/runner_test.clj
@@ -1,7 +1,0 @@
-(ns eftest.runner-test
-  (:require [clojure.test :refer :all]
-            [eftest.runner :as eftest]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))


### PR DESCRIPTION
Hey James,

Hope this finds you well.

I was hoping to add some tests but it's tricky testing the tests, as I'm sure you're aware. I thought about adding a nested Leiningen project and shelling out to make sure we do the right thing, but with the progress bar and additional complexity…

This PR returns the hash-map of test summary info so we can programmatically do things. The commit below describes what's going on. Oh, and I snuck a small documentation fix in that I thought you'd be cool with. If you'd prefer it in a separate PR please cherry pick it out.

All the best old friend,

Other James

---

Previously running tests via `eftest.runner/run-tests` would return `nil` making
it impossible to know if we have a green/red build. This change returns a map of
information similar to that of clojure.test itself (with an additional
`:duration` key-value pair that describes how long our tests took to run).

This change makes it possible to use eftest's `run-tests` programmatically,
which allows us to use eftest in CI and other systems where we may need to
forward the success or failure of a given test run to some external system.

The return value of a test run now looks something like this:

    {:duration 12, :error 0, :fail 1, :pass 0, :test 1, :type :summary}

This new return value means you can something like this:

    (let [{:keys [error fail]} (-> "test"
                                    eftest.runner/find-tests
                                    eftest.runner/run-tests)]
      (when-not (and (zero? error) (zero? fail))
        (System/exit (Math/max 255 (+ (:error m) (:fail m)))))

Note the use of `Math/max`. You can't use a status code larger than 255!

Fixes #3.
