### PR TITLE
Support leiningen test selectors in lein eftest

### DIFF
--- a/lein-eftest/src/leiningen/eftest.clj
+++ b/lein-eftest/src/leiningen/eftest.clj
@@ -1,6 +1,7 @@
 (ns leiningen.eftest
   (:require [leiningen.core.eval :as eval]
             [leiningen.core.main :as main]
+            [leiningen.test :as test]
             [leiningen.core.project :as project]))
 
 (def eftest-profile
@@ -12,20 +13,80 @@
 (defn- require-form [project]
   `(require 'eftest.runner '~(report-namespace project)))
 
-(defn- testing-form [project]
-  (let [paths   (vec (:test-paths project))
-        options (:eftest project {})]
-    `(let [summary#   (eftest.runner/run-tests (eftest.runner/find-tests ~paths) ~options)
-           exit-code# (+ (:error summary#) (:fail summary#))]
+;; Forms copied from leiningen.test
+(def form-for-suppressing-unselected-tests
+  "A function that figures out which vars need to be suppressed based on the
+  given selectors, moves their :test metadata to :leiningen/skipped-test (so
+  that clojure.test won't think they are tests), runs the given function, and
+  then sets the metadata back."
+  `(fn [namespaces# selectors# func#]
+     (let [copy-meta# (fn [var# from-key# to-key#]
+                        (if-let [x# (get (meta var#) from-key#)]
+                          (alter-meta! var# #(-> % (assoc to-key# x#) (dissoc from-key#)))))
+           vars#      (if (seq selectors#)
+                        (->> namespaces#
+                             (mapcat (comp vals ns-interns))
+                             (remove (fn [var#]
+                                       (some (fn [[selector# args#]]
+                                               (let [sfn# (if (vector? selector#)
+                                                            (second selector#)
+                                                            selector#)]
+                                                 (apply sfn#
+                                                        (merge (-> var# meta :ns meta)
+                                                               (assoc (meta var#) ::var var#))
+                                                        args#)))
+                                             selectors#)))))
+           copy#      #(doseq [v# vars#] (copy-meta# v# %1 %2))]
+       (copy# :test :leiningen/skipped-test)
+       (try (func#)
+            (finally
+              (copy# :leiningen/skipped-test :test))))))
+
+(defn- form-for-select-namespaces [namespaces selectors]
+  `(reduce (fn [acc# [f# args#]]
+             (if (vector? f#)
+               (filter #(apply (first f#) % args#) acc#)
+               acc#))
+           '~namespaces ~selectors))
+
+(defn- form-for-nses-selectors-match [selectors ns-sym]
+  `(distinct
+    (for [ns#       ~ns-sym
+          [_# var#] (ns-publics ns#)
+          :when     (some (fn [[selector# args#]]
+
+                            (apply (if (vector? selector#)
+                                     (second selector#)
+                                     selector#)
+                                   (merge (-> var# meta :ns meta)
+                                          (assoc (meta var#) ::var var#))
+                                   args#))
+                          ~selectors)]
+      ns#)))
+
+(defn- testing-form [project namespaces selectors]
+  (let [selectors (vec selectors)
+        ns-sym    (gensym "namespaces")
+        options   (:eftest project {})]
+    `(let [~ns-sym              ~(form-for-select-namespaces namespaces selectors)
+           _#                   (when (seq ~ns-sym) (apply require :reload ~ns-sym))
+           selected-namespaces# ~(form-for-nses-selectors-match selectors ns-sym)
+           summary#             (~form-for-suppressing-unselected-tests
+                                 selected-namespaces# ~selectors
+                                 #(eftest.runner/run-tests
+                                   (eftest.runner/find-tests selected-namespaces#)
+                                   ~options))
+           exit-code#           (+ (:error summary#) (:fail summary#))]
        (if ~(= :leiningen (:eval-in project))
          exit-code#
          (System/exit exit-code#)))))
 
 (defn eftest
   "Run the project's tests with Eftest."
-  [project]
-  (let [project (project/merge-profiles project [:leiningen/test :test eftest-profile])
-        form    (testing-form project)]
+  [project & tests]
+  (let [[nses selectors] (test/read-args tests project)
+        project          (project/merge-profiles project [:leiningen/test :test eftest-profile])
+        form             (testing-form project nses selectors)]
     (try
       (when-let [n (eval/eval-in-project project form (require-form project))]
         (when (and (number? n) (pos? n))


### PR DESCRIPTION
The code uses `leiningen.test/read-args` to extract a sequence of namespaces and test selectors from the task args, then uses the forms in `leiningen.test` to pick the namespaces and args that match the given (or default) selectors. I believe the behaviour is exactly the same as of `lein test`:

* Run the tests in the `:test-paths` by default, filtering with the `:default` test-selector when present.
* Accept a list of namespaces or files (which get translated to namespaces) to test.
* Accept the special `:only` selector to run specific vars.
* Accept test selectors configured in the project map, which are applied both on namespaces and test vars to select the tests that should run.
* Accept the `:all` selector which runs all the tests in the given namespaces regardless of the configured selectors.

Note I'm using some private functions from `leiningen.test`: 

```clojure
(def form-for-select-namespaces #'test/form-for-select-namespaces)
(def form-for-nses-selectors-match #'test/form-for-nses-selectors-match)
```
I imagine that's not a good practice, so let me know if you want me to copy the definitions of those functions over to this project.
