### PR TITLE
Add namespace support for :eftest/synchronized

### DIFF
--- a/eftest/src/eftest/runner.clj
+++ b/eftest/src/eftest/runner.clj
@@ -12,7 +12,8 @@
   (let [lock (Object.)] (fn [x] (locking lock (f x)))))
 
 (defn- synchronized? [v]
-  (-> v meta :eftest/synchronized true?))
+  (or (-> v meta :eftest/synchronized true?)
+      (-> v meta :ns meta :eftest/synchronized true?)))
 
 (defn- test-vars [ns vars opts]
   (let [once-fixtures (-> ns meta ::test/once-fixtures test/join-fixtures)


### PR DESCRIPTION
Consider both the var and namespace meta when looking for :eftest/synchronized tests, that way a whole file can be marked to run serially.

reopened with new commit message as requested in #13 