### PR TITLE
Add an output-catching reporter

### DIFF
--- a/eftest/src/eftest/report/output_catcher.clj
+++ b/eftest/src/eftest/report/output_catcher.clj
@@ -1,0 +1,53 @@
+(ns eftest.report.output-catcher
+  "A test reporter that hides test output for successful tests."
+  (:require [clojure.test :as test]
+            [eftest.report :refer [*context*]]
+            [eftest.report.pretty :as pretty]
+            [eftest.report.progress :as progress]
+            [io.aviso.ansi :as ansi])
+  (:import java.io.StringWriter))
+
+(def ^:dynamic *fonts*
+  {:banner ansi/white-font})
+
+(defmulti before-report :type)
+
+(defmethod before-report :default [m])
+
+(defmethod before-report :begin-test-ns [m]
+  (swap! *context* assoc ::tests-to-print #{}))
+
+(defn- mark-for-printing []
+  (let [test-var (first test/*testing-vars*)]
+    (swap! *context* update ::tests-to-print conj test-var)))
+
+(defmethod before-report :error [m]
+  (mark-for-printing))
+
+(defmethod before-report :fail [m]
+  (mark-for-printing))
+
+(defmethod before-report :end-test-var [m]
+  (let [output (str *out*)
+        print? (contains? (::tests-to-print @*context*) (:var m))]
+    (pop-thread-bindings)
+    (when print?
+      (test/with-test-out
+        (println pretty/*divider*)
+        (print (:banner *fonts*))
+        (println "==== Test output for" (:var m) "====" (:reset pretty/*fonts*))
+        (print output)
+        (print (:banner *fonts*))
+        (println "==== Test output ends ====" (:reset pretty/*fonts*))))))
+
+(defn after-report [m]
+  (when (= (:type m) :begin-test-var)
+    (push-thread-bindings {#'*out* (StringWriter.)})))
+
+(defn wrap [f]
+  (fn [m]
+    (before-report m)
+    (f m)
+    (after-report m)))
+
+(def report (wrap progress/report))


### PR DESCRIPTION
This patch implements the feature discussed in #9. It catches whatever is printed to `*out*` by a test and prints it to the user only if the test in question fail.

Some thoughts:
1. Since `*out*` is thread-local, this should work correctly when tests are run in parallel.
2. This patch won't see the output from various Java logging libraries, including [tools.logging](https://github.com/clojure/tools.logging). It does work with [Timbre](https://github.com/ptaoussanis/timbre), though.
3. When trying this out on some real project, I found out that it's the fixtures that are noisy, not the tests. This patch does nothing about the fixtures.

Point 2 could be possibly addressed by using [`System/setOut`][setout], but that would require some extra work to handle parallel tests correctly. Not sure what would be the best way to handle point 3 – for example, what would one do with the `:once` fixtures?

[setout]: https://docs.oracle.com/javase/7/docs/api/java/lang/System.html#setOut(java.io.PrintStream)