### PR TITLE
Capture test output and print it only for failing tests

### DIFF
--- a/eftest/src/eftest/output_capture.clj
+++ b/eftest/src/eftest/output_capture.clj
@@ -1,0 +1,54 @@
+(ns eftest.output-capture
+  (:require [clojure.string :as str])
+  (:import (java.io OutputStream ByteArrayOutputStream PrintStream PrintWriter)
+           (java.nio.charset StandardCharsets)))
+
+(def captured-output-contexts (atom {}))
+
+(defn thread-id []
+  (-> (Thread/currentThread)
+      (.getId)))
+
+(defn init-capture-buffer [buffer]
+  (or buffer (ByteArrayOutputStream.)))
+
+(defn get-capture-buffer ^ByteArrayOutputStream []
+  (let [id (thread-id)]
+    (-> (swap! captured-output-contexts update id init-capture-buffer)
+        (get id))))
+
+(defn flush-captured-output ^String []
+  (let [output (some-> (get-capture-buffer)
+                       .toByteArray
+                       (String. StandardCharsets/UTF_8)
+                       str/trim)]
+    (when-not (str/blank? output)
+      output)))
+
+(defn create-proxy-output-stream ^OutputStream []
+  (proxy [OutputStream] []
+    (write
+      ([data]
+       (when-let [target (get-capture-buffer)]
+         (if (instance? Integer data)
+           (.write target ^int data)
+           (.write target ^bytes data 0 (alength ^bytes data)))))
+      ([data off len]
+       (when-let [target (get-capture-buffer)]
+         (.write target data off len))))))
+
+(defn init-capture []
+  (let [old-out System/out
+        old-err System/err
+        proxy-output-stream (create-proxy-output-stream)
+        new-stream (PrintStream. proxy-output-stream)
+        new-writer (PrintWriter. proxy-output-stream)]
+    (System/setOut new-stream)
+    (System/setErr new-stream)
+    {:captured-writer new-writer
+     :old-system-out old-out
+     :old-system-err old-err}))
+
+(defn restore-capture [{:keys [old-system-out old-system-err]}]
+  (System/setOut old-system-out)
+  (System/setErr old-system-err))

--- a/eftest/src/eftest/report/pretty.clj
+++ b/eftest/src/eftest/report/pretty.clj
@@ -5,7 +5,8 @@
             [io.aviso.ansi :as ansi]
             [io.aviso.exception :as exception]
             [io.aviso.repl :as repl]
-            [puget.printer :as puget]))
+            [puget.printer :as puget]
+            [eftest.output-capture :as capture]))
 
 (def ^:dynamic *fonts*
   "The ANSI codes to use for reporting on tests."
@@ -74,7 +75,11 @@
     (if (and (sequential? expected)
              (= (first expected) '=))
       (equals-fail-report m)
-      (predicate-fail-report m))))
+      (predicate-fail-report m))
+    (when-let [output (capture/flush-captured-output)]
+      (println "\nTest output: ====================================================")
+      (println output)
+      (println "\n================================================================="))))
 
 (defmethod report :error [{:keys [message expected actual] :as m}]
   (test/with-test-out
@@ -88,7 +93,11 @@
    (if (instance? Throwable actual)
      (binding [exception/*traditional* true, exception/*fonts* *fonts*]
        (repl/pretty-print-stack-trace actual test/*stack-trace-depth*))
-     (puget/cprint actual))))
+     (puget/cprint actual))
+   (when-let [output (capture/flush-captured-output)]
+     (println "\nTest output: ====================================================")
+     (println output)
+     (println "\n================================================================="))))
 
 (defn- pluralize [word count]
   (if (= count 1) word (str word "s")))


### PR DESCRIPTION
This PR captures `*out*`, `*err*`, `System/out` and `System/err` for each test thread into a ByteArrayOutputStream. The test reporter requests and prints the output for failing tests.

The implementation has a map `eftest.output-capture/captured-output-contexts` that is keyed by the thread id, and has the output capturing context as a value. The context has a buffer for output and a `PrintWriter` and `PrintStream` instances that both write to the buffer.

Before tests are run, the `*out*`, `*err*`, `System/out` and `System/err` are redirected to a proxied implementations of `PrintWriter` and `PrintStream`. These proxies intercept calls and redirect them to actual writer and stream found from `captured-output-contexts` selected by the current thread.

This allows keeping output from multiple threads separate, even with the `System/out` and `System/err` being shared by all threads.

Since the `PrintStream` and `PrintWriter` are concrete classes without suitable interfaces we can't use `clojure.core/proxy`. This implementation uses the `javassist` library for byte code generation.

The test reporter can then ask the generated output for the current thread and print it.