### PR TITLE
Add support for reporting to a file via project.clj

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ You can customize the reporter and set the concurrency by adding an
 
 ```clojure
 :eftest {:multithread? false
-         :report clojure.report.junit/report}
+         :report clojure.report.junit/report
+         ;; You can optionally write the output to a file like so:
+         :report-to-file "target/junit.xml"}
 ```
 
 Leiningen test selectors also work. With namespaces:


### PR DESCRIPTION
Hi James,

I think this will work as-is but can't test it automatically very easily because I can't get Leiningen to pull in an unreleased, local version of both eftest and lein-eftest (I don't think plugins are supported when it comes to checkouts?).

I've added a comment explaining why I've used an `or` as opposed to whatever is in `(-> project :eftest :report)` and that I'm duplicating the default reporter logic with this change. I'm not sure if you want to address the latter?

If you have an idea how to automate testing this I'm happy to implement something, but kinda stumped given the logic is inside a Leiningen plugin.

All the best!