### PR TITLE
Add timer and warnings for long tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,26 @@ do this set the `:fail-fast?` option to `true`:
 user=> (run-tests (find-tests "test") {:fail-fast? true})
 ```
 
+#### Long test reporting
+
+If you wish to monitor the length of time to run each test, you can
+set the `:test-warn-time` option to the threshold in milliseconds you
+wish to warn on long test for. The measured duration includes the
+running of `:each-fixtures`, but not `:once-fixtures`.
+
+If you know a particular test to be slow and are ok with that, and
+don't want to continually be warned about it, you can add the metadata
+`:eftest/slow` to either the individual test, or the entire namespace,
+to prevent reporting.
+
+Note that currently only the `pretty` and `progress` reporters support
+logging long tests.
+
+```clojure
+;; Warns for all tests that take longer than 500ms
+user=> (run-tests (find-tests "test") {:test-warn-time 500})
+```
+
 ### Plugin
 
 To use the Lein-Eftest plugin, just run:

--- a/eftest/src/eftest/report/pretty.clj
+++ b/eftest/src/eftest/report/pretty.clj
@@ -34,7 +34,8 @@
   (let [test-var (first test/*testing-vars*)]
     (str (:clojure-frame *fonts*) (-> test-var meta :ns ns-name) "/"
          (:function-name *fonts*) (-> test-var meta :name) (:reset *fonts*)
-         " (" (:source *fonts*) file ":" line (:reset *fonts*) ")")))
+         (when (or file line)
+           " (" (:source *fonts*) file ":" line (:reset *fonts*) ")"))))
 
 (defn- diff-all [expected actuals]
   (map vector actuals (map #(take 2 (data/diff expected %)) actuals)))
@@ -129,6 +130,12 @@
 
 (defn- format-interval [duration]
   (format "%.3f seconds" (double (/ duration 1e3))))
+
+(defmethod report :long-test [{:keys [duration] :as m}]
+  (test/with-test-out
+    (print *divider*)
+    (println (str (:fail *fonts*) "LONG TEST" (:reset *fonts*) " in") (testing-vars-str m))
+    (when duration (println "Test took" (format-interval duration) "seconds to run"))))
 
 (defmethod report :summary [{:keys [test pass fail error duration]}]
   (let [total (+ pass fail error)

--- a/eftest/src/eftest/report/progress.clj
+++ b/eftest/src/eftest/report/progress.clj
@@ -63,3 +63,10 @@
   (test/with-test-out
     (print-progress (swap! report/*context* update-in [:bar] prog/done))
     (pretty/report m)))
+
+(defmethod report :long-test [m]
+  (test/with-test-out
+    (print clear-line)
+    (binding [pretty/*divider* "\r"] (pretty/report m))
+    (newline)
+    (print-progress @report/*context*)))


### PR DESCRIPTION
- Time the duration for all tests
- Allow user to specify a minimum threshold in milliseconds, if a test exceeds this duration, then print a warning into the report output