### PR TITLE
Create output directory if required on report-to-file

### DIFF
--- a/eftest/src/eftest/report.clj
+++ b/eftest/src/eftest/report.clj
@@ -15,6 +15,7 @@
   (let [output-key [::output-files output-file]]
     (fn [m]
       (when (= (:type m) :begin-test-run)
+        (io/make-parents (io/file output-file))
         (swap! *context* assoc-in output-key (io/writer output-file)))
       (let [writer (get-in @*context* output-key)]
         (binding [*test-out* writer]

--- a/eftest/test/eftest/report_test.clj
+++ b/eftest/test/eftest/report_test.clj
@@ -1,0 +1,25 @@
+(ns eftest.report-test
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :as io]
+            [eftest.report.junit :as junit]
+            [eftest.runner :as sut]
+            [eftest.report :as report]))
+
+(in-ns 'eftest.test-ns.single-failing-test)
+(clojure.core/refer-clojure)
+(clojure.core/require 'clojure.test)
+(clojure.test/deftest single-failing-test
+  (clojure.test/is (= 1 2)))
+
+(in-ns 'eftest.report-test)
+
+(defn delete-dir [file]
+  (doseq [f (reverse (file-seq file))]
+    (.delete f)))
+
+(deftest report-to-file-test
+  (delete-dir (io/file "target/test-out"))
+  (-> 'eftest.test-ns.single-failing-test
+      sut/find-tests
+      (sut/run-tests {:report (report/report-to-file junit/report "target/test-out/junit.xml")}))
+  (is (string? (slurp "target/test-out/junit.xml"))))


### PR DESCRIPTION
Also adds tests which check report-to-file, junit report and removes the target directory first to ensure report-to-file creates the directory if it doesn't exist.