### PR TITLE
Fix running Leiningen eftest task with explicitly specified Leiningen profile

### DIFF
--- a/lein-eftest/src/leiningen/eftest.clj
+++ b/lein-eftest/src/leiningen/eftest.clj
@@ -100,9 +100,9 @@
 (defn eftest
   "Run the project's tests with Eftest."
   [project & tests]
-  (let [[nses selectors] (test/read-args tests project)
-        profiles         [:leiningen/test :test eftest-profile]
+  (let [profiles         [:leiningen/test :test eftest-profile]
         project          (project/merge-profiles project profiles)
+        [nses selectors] (test/read-args tests project)
         form             (testing-form project nses selectors)]
     (try
       (when-let [n (eval/eval-in-project project form (require-form project))]


### PR DESCRIPTION
Currently to run `eftest` Leiningen task with explicit Leiningen profile (using `with-profile`) it's required to also explicitly include `leiningen/test` profile (which includes default test selector selecting all available tests) or explicitly specifying custom test selector.

For example this won't find any tests:

```
gsnewmark@asgard:/tmp/eftest-profiles|
⇒  lein with-profiles dev eftest
No tests found.
```

But adding `leiningen/test` will find all tests:

```
gsnewmark@asgard:/tmp/eftest-profiles|
⇒  lein with-profiles dev,leiningen/test eftest

FAIL in eftest-profiles.core-test/a-test (core_test.clj:7)                      
FIXME, I fail.
expected: 0
  actual: 1


1/1   100% [==================================================]  ETA: 00:00

Ran 1 tests in 0,028 seconds
1 assertion, 1 failure, 0 errors.
Tests failed.
Error encountered performing task 'eftest' with profile(s): 'dev,test'
Tests failed.
```

Reproducible example (just the default Leiningen-generated project with added `eftest` plugin) https://github.com/gsnewmark/eftest-profiles

To be [consistent with default Leiningen test runner](https://github.com/technomancy/leiningen/blob/ecd3853158524ad545d171200c8a38d976ad556c/src/leiningen/test.clj#L225-L226), which doesn't require specifying `leiningen/test` every time, we need to implicitly merge test-specific profiles into project **before** calculating test selectors, not just before test form generation.