### PR TITLE
Fix support for single-test Leiningen selectors

### DIFF
--- a/lein-eftest/src/leiningen/eftest.clj
+++ b/lein-eftest/src/leiningen/eftest.clj
@@ -38,7 +38,7 @@
                                                             selector#)]
                                                  (apply sfn#
                                                         (merge (-> var# meta :ns meta)
-                                                               (assoc (meta var#) ::var var#))
+                                                               (assoc (meta var#) :leiningen.test/var var#))
                                                         args#)))
                                              selectors#)))))
            copy#      #(doseq [v# vars#] (copy-meta# v# %1 %2))]
@@ -63,7 +63,7 @@
                                      (second selector#)
                                      selector#)
                                    (merge (-> var# meta :ns meta)
-                                          (assoc (meta var#) ::var var#))
+                                          (assoc (meta var#) :leiningen.test/var var#))
                                    args#))
                           ~selectors)]
       ns#)))


### PR DESCRIPTION
Selectors [generated by Leiningen's `leiningen.test/read-args`](https://github.com/weavejester/eftest/blob/c76be8f757bccda3ef6e726f67ad0c1aff2f4f6b/lein-eftest/src/leiningen/eftest.clj#L103) rely on [checking namespace-qualified keyword `:leiningen.test/var`](https://github.com/technomancy/leiningen/blob/ecd3853158524ad545d171200c8a38d976ad556c/src/leiningen/test.clj#L166) to check if particular var was selected, but currently `:leiningen.eftest/var` is passed instead :slightly_smiling_face: 

Fixes #37 