### PR TITLE
Catch unhandled exceptions in fixtures

### DIFF
--- a/eftest/src/eftest/output_capture.clj
+++ b/eftest/src/eftest/output_capture.clj
@@ -5,7 +5,7 @@
 (def ^:dynamic *test-buffer* nil)
 
 (defn read-test-buffer []
-  (String. (.toByteArray *test-buffer*)))
+  (some-> *test-buffer* (.toByteArray) (String.)))
 
 (def active-buffers (atom #{}))
 

--- a/eftest/src/eftest/report.clj
+++ b/eftest/src/eftest/report.clj
@@ -8,6 +8,11 @@
   additional statistics and information during the tests."
   nil)
 
+(def ^:dynamic *testing-path*
+  "2-element vector [ns scope] where scope is either :clojure.test/once-fixtures,
+  :clojure.test/each-fixtures or var under test"
+  nil)
+
 (defn report-to-file
   "Wrap a report function so that its output is directed to a file. output-file
   should be something that can be coerced into a Writer."


### PR DESCRIPTION
Hi James!

Right now if there’s an exception inside fixture, it’s not handled gracefully: output/stacktrace is not shown, parallel tests continue their execution.

I wrapped once-fixtures and each-fixtures in try/catch block and handled thrown exceptions. I also made some adjustments to ouput to clearly show what’s broken and where.

Hope you find it useful. Great project — thanks!