### PR TITLE
Show how to run from CLI with tools.deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ replacement, add the following to your project `:plugins`:
 
     [lein-eftest "0.5.2"]
 
+Alternatively, if your project uses
+[the CLI tools introduced in Clojure 1.9](https://clojure.org/guides/deps_and_cli),
+you can try it out from the command line:
+
+```shell
+clojure -Sdeps '{:deps {eftest {:mvn/version "0.5.2"}} :paths ["src" "test"]}' \
+        -e "(require '[eftest.runner :refer [find-tests run-tests]]) (run-tests (find-tests \"test\"))"
+```
+
 ## Screenshots
 
 When all the tests pass, it looks like this:


### PR DESCRIPTION
I tested this on my project, and it works for me.

It should theoretically be possible to create a profile in a project’s `deps.edn` that would pass a `-e ...` argument to `clojure.main` that’d be identical to that added herein, but I haven’t been able to figure out how; I always run into some Bash quoting problem that is beyond my Bash skills to debug.

Apart from that possibility, the other options that I’m aware of for using eftest in a project using `deps.edn` are to either add a `main-` function to eftest (as in #43 and #44) or to add a test-runner-runner namespace/script to the project under test (which is what I’ve done in my project).