### PR TITLE
Use a single threadpool configured via new option :threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,29 @@ Or you can synchronize the entire namespace:
             [foo.core :refer :all]))
 ```
 
+##### Setting the number of threads used
+
+When multithreading is enabled, Eftest uses a single fixed-threadpool
+[`ExecutorService`][executorservice] to run all selected tests.
+
+By default, Eftest will instantiate the threadpool with the number of processors
+(cores) available to the JVM, as reported by
+[`Runtime.availableProcessors`][availableprocessors]. (NB: in some
+circumstances, such as [in a CircleCI test container][resource-class],
+`Runtime.availableProcessors` returns an erroneous value.)
+
+[executorservice]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ExecutorService.html
+[availableprocessors]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.html#availableProcessors()
+[resource-class]: https://circleci.com/docs/2.0/configuration-reference/#resource_class
+
+Users can override the default behavior by including the key `:thread-count`
+in the options map supplied to `run-tests` with the value being any
+positive integer:
+
+```clojure
+user=> (run-tests (find-tests "test") {:thread-count 4})
+```
+
 #### Reporting
 
 You can also change the reporting function used. For example, if you
@@ -177,11 +200,12 @@ To use the Lein-Eftest plugin, just run:
 lein eftest
 ```
 
-You can customize the reporter and set the concurrency by adding an
-`:eftest` key to your project map:
+You can customize the reporter and configure the concurrency settings
+by adding an `:eftest` key to your project map:
 
 ```clojure
-:eftest {:multithread? false
+:eftest {:multithread? :vars
+         :thread-count 4
          :report eftest.report.junit/report
          ;; You can optionally write the output to a file like so:
          :report-to-file "target/junit.xml"}


### PR DESCRIPTION
I’ve been debugging slow test suite execution times (wall-clock-time) in
my test suite and I found a few problems:

* When running in CircleCI, `Runtime.availableProcessors` always
  [erroneously returns 32](https://circleci.com/docs/2.0/configuration-reference/#resource_class), when the correct number is generally 2–8.
* When `:multithread` is set to `true` (the default), each namespace is
  tested simultaneously with its own dedicated threadpool, and each
  threadpool uses `(+ 2 (.availableProcessors runtime))` threads.

The combination of these factors means that for a project with, say, 4
namespaces to be tested, when run on CircleCI four threadpools would be
created, each with 34 threads, and they’d all be running tests
simultaneously, which means that 136 threads would be simultaneously
executing tests. If those tests are computationally intensive, as e.g.
property tests tend to be, then that can drastically lower test
throughput on a container that may actually have only 2 or 4 cores
available.

And due to test.check and clojure.spec, such computationally intensive
property tests are becoming more common in the Clojure community.

These changes address these issues like so:

* A single threadpool is always used to run all tests
  * Makes it easier to control and reason about the number of threads
    used to execute tests
  * Even in the CircleCI scenario, only 32 threads total would be used,
    rather than `(* 32 (count namespaces-under-test))`
* A new option `:threads` enables users to specify the number of threads
  they’d like to be used to execute tests
  * So in circumstances such as that in CircleCI, it should be fairly
    easy for users to work around the erroneous value reported by Java
  * The default value is changed to be the value returned by `Runtime`,
    rather than that value plus two. This is because I think that
    computationally intensive test suites are becoming more common in
    the Clojure community, and this default would therefore be a little
    more broadly appropriate, I think. It also just feels more intuitive
    to me, more in line with the principle of least astonishment.

All the tests pass for me, well, except for the test that was already failing in master (see #62) (I also rebased this branch onto that bugfix branch locally and then _all_ the tests passed).