### PR TITLE
Upgrade puget 1.0.3 => 1.1.1

### DIFF
--- a/eftest/project.clj
+++ b/eftest/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/tools.namespace "0.2.11"]
                  [progrock "0.1.2"]
                  [io.aviso/pretty "0.1.34"]
-                 [mvxcvi/puget "1.0.3"]]
+                 [mvxcvi/puget "1.1.1"]]
   :plugins [[lein-eftest "0.5.7"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10" "eftest"]}
   :profiles


### PR DESCRIPTION
There is a compiler exception that occurs with JDK 11 related to [a new toArray method in the java.util.Collection interface](https://www.deps.co/blog/how-to-upgrade-clojure-projects-to-use-java-11/#java-util-collection-toarray).

eftest is affected by this due to a transitive dependency on clojure.core.rrb-vector, via puget.

The symptom is that I get this exception when I try to run tests via bat-test (which uses eftest):

```
     java.lang.IllegalArgumentException: Must hint overloaded method: toArray
clojure.lang.Compiler$CompilerException: Syntax error compiling deftype* at (clojure/core/rrb_vector/rrbt.clj:282:1).
    data: {#object[clojure.lang.Keyword 0x35356aef ":clojure.error/phase"] #object[clojure.lang.Keyword 0x2596ae35 ":compile-syntax-check"], #object[clojure.lang.Keyword 0x358b0b42 ":clojure.error/line"] 282, #object[clojure.lang.Keyword 0x34b1bc0f ":clojure.error/column"] 1, #object[clojure.lang.Keyword 0x59fbfc5d ":clojure.error/source"] "clojure/core/rrb_vector/rrbt.clj", #object[clojure.lang.Keyword 0x498c0651 ":clojure.error/symbol"] #object[clojure.lang.Symbol 0x24b0c539 "deftype*"]}
             clojure.lang.ExceptionInfo: Syntax error compiling deftype* at (clojure/core/rrb_vector/rrbt.clj:282:1).
    line: 247
```

The issue has been fixed upstream in clojure.core.rrb-vector, and puget has started using a newer version of clojure.core.rrb-vector that includes the fix. So, I'm working on getting this fix downstream into eftest and then bat-test. Upgrading puget should do the trick for eftest.

I ran the tests with this upgraded dependency and they pass, FWIW.