### PR TITLE
Fix #56 wrong test names in slow tests report

### DIFF
--- a/eftest/src/eftest/runner.clj
+++ b/eftest/src/eftest/runner.clj
@@ -26,7 +26,7 @@
       (< 0 (:error @test/*report-counters* 0))
       (< 0 (:fail @test/*report-counters* 0))))
 
-(defn- wrap-test-with-timer [test-fn test-warn-time]
+(defn- wrap-test-with-timer [test-fn ns test-warn-time]
   (fn [v]
     (let [start-time (System/nanoTime)
           result     (test-fn v)
@@ -35,7 +35,8 @@
       (when (and (not (known-slow? v))
                  (number? test-warn-time)
                  (<= test-warn-time duration))
-        (binding [clojure.test/*testing-vars* (conj clojure.test/*testing-vars* v)]
+        (binding [clojure.test/*testing-vars* (conj clojure.test/*testing-vars* v)
+                  report/*testing-path* [ns v]]
           (test/report {:type     :long-test
                         :duration duration
                         :var      v})))
@@ -99,7 +100,7 @@
                                           (test/test-var v))))
                                   (catch Throwable t
                                     (test/do-report (fixture-exception t)))))))
-                          (wrap-test-with-timer test-warn-time))]
+                          (wrap-test-with-timer ns test-warn-time))]
     (binding [report/*testing-path* [ns ::test/once-fixtures]]
       (try
         (once-fixtures

--- a/eftest/test/eftest/runner_test.clj
+++ b/eftest/test/eftest/runner_test.clj
@@ -14,6 +14,12 @@
 (clojure.test/deftest another-failing-test
   (clojure.test/is (= 3 4)))
 
+(in-ns 'eftest.test-ns.slow-test)
+(clojure.core/refer-clojure)
+(clojure.core/require 'clojure.test)
+(clojure.test/deftest a-slow-test
+  (clojure.test/is (true? (do (Thread/sleep 10) true))))
+
 (in-ns 'eftest.runner-test)
 
 (defn with-test-out-str* [f]
@@ -58,3 +64,9 @@
     (println out)
     (is (re-find #"(?m)expected: 1\n  actual: 2" out))
     (is (re-find #"(?m)expected: 3\n  actual: 4" out))))
+
+(deftest test-slow-test-report
+  (testing "should fail with an accurate var location"
+    (let [out (:output
+                (test-run-tests ['eftest.test-ns.slow-test] {:test-warn-time 5}))]
+      (is (re-find #"LONG TEST in eftest.test-ns.slow-test/a-slow-test\n" out)))))


### PR DESCRIPTION
- fixes #56