### PR TITLE
Update project description and URL

### DIFF
--- a/lein-eftest/project.clj
+++ b/lein-eftest/project.clj
@@ -1,6 +1,6 @@
 (defproject lein-eftest "0.5.9"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+  :description "A fast and pretty Clojure test runner"
+  :url "https://github.com/weavejester/eftest"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true)


### PR DESCRIPTION
💁 Makes the traversal from https://clojars.org/lein-eftest to the source code easier for consumers of this library.