### PR TITLE
Only use require :reload when :eval-in :nrepl

### DIFF
--- a/lein-eftest/src/leiningen/eftest.clj
+++ b/lein-eftest/src/leiningen/eftest.clj
@@ -84,7 +84,11 @@
   (let [selectors (vec selectors)
         ns-sym    (gensym "namespaces")]
     `(let [~ns-sym              ~(form-for-select-namespaces namespaces selectors)
-           _#                   (when (seq ~ns-sym) (apply require :reload ~ns-sym))
+           _#                   (when (seq ~ns-sym)
+                                  (apply require
+                                         ~@(when (= :nrepl (:eval-in project))
+                                             [:reload])
+                                         ~ns-sym))
            selected-namespaces# ~(form-for-nses-selectors-match selectors ns-sym)
            options#             ~(-> project :eftest process-options)
            summary#             (~form-for-suppressing-unselected-tests


### PR DESCRIPTION
Close https://github.com/weavejester/eftest/issues/81

Uses similar approach to [upstream fix](https://github.com/technomancy/leiningen/blob/2586957f9d099ff11d50d312a6daf397c2a06fb1/src/leiningen/test.clj#L89-L92). We'd only need to `:reload` if the current REPL is persistent via an `:nrepl` session.