### PR TITLE
Update to use org.clj-commons/pretty 2.6.0

### DIFF
--- a/eftest/project.clj
+++ b/eftest/project.clj
@@ -3,10 +3,10 @@
   :url "https://github.com/weavejester/eftest"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.namespace "1.3.0"]
                  [progrock "0.1.2"]
-                 [io.aviso/pretty "1.3"]
+                 [org.clj-commons/pretty "2.6.0"]
                  [mvxcvi/puget "1.3.4"]]
   :plugins [[lein-eftest "0.6.0"]]
   :aliases {"test-all"

--- a/eftest/src/eftest/report/pretty.clj
+++ b/eftest/src/eftest/report/pretty.clj
@@ -43,9 +43,8 @@
          [(:function-name *fonts*) scope])
 
        (var? scope)
-       (list
-         [(:clojure-frame *fonts*) (ns-name ns) "/"
-          [(:function-name *fonts*) (:name (meta scope))]]))
+       [(:clojure-frame *fonts*) (ns-name ns) "/"
+        [(:function-name *fonts*) (:name (meta scope))]])
      (when (or file line)
        (list
          " ("

--- a/eftest/src/eftest/report/progress.clj
+++ b/eftest/src/eftest/report/progress.clj
@@ -1,6 +1,7 @@
 (ns eftest.report.progress
   "A test reporter with a progress bar."
-  (:require [clojure.test :as test]
+  (:require [clj-commons.ansi :as ansi]
+            [clojure.test :as test]
             [eftest.report :as report]
             [eftest.report.pretty :as pretty]
             [progrock.core :as prog]))
@@ -8,11 +9,9 @@
 (def ^:private clear-line (apply str "\r" (repeat 80 " ")))
 
 (defn- colored-format [state]
-  (str ":progress/:total   :percent% ["
-       (if state
-         (str (pretty/*fonts* state) ":bar" (pretty/*fonts* :reset))
-         ":bar")
-       "]  ETA: :remaining"))
+  (ansi/compose ":progress/:total   :percent% ["
+                [(when state (pretty/*fonts* state)) ":bar"]
+                "]  ETA: :remaining"))
 
 (defn- print-progress [{:keys [bar state]}]
   (prog/print bar {:format (colored-format state)}))


### PR DESCRIPTION
io.aviso/pretty is past its EOL and has been replaced with org.clj-commons/pretty, which is actively maintained.

Non-backwards compatible changes:
- The `eftest.report.pretty/*fonts*` has changed to be keywords, not direct ANSI code strings
- The Clojure version has advanced to 1.9, to accommodate pretty
